### PR TITLE
Revise security policy for issue reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,21 +1,9 @@
-# Security Policy
+# Report A Security Issue
 
-## Supported Versions
+You can report a security issue through the Github advisory for Velaterm.
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
+This is only Applicable to the latest release version
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+Don't open a public Github Issue for Security related Issues.
 
-## Reporting a Vulnerability
-
-Use this section to tell people how to report a vulnerability.
-
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+Thanks,


### PR DESCRIPTION
Updated the security policy to focus on reporting security issues through GitHub advisory and removed details about supported versions and reporting vulnerabilities.