### PR TITLE
Fix AppImage failing to start from a desktop launcher (anchor WEBKIT_EXEC_PATH to the bundle)

### DIFF
--- a/src-tauri/src/appimage.rs
+++ b/src-tauri/src/appimage.rs
@@ -105,6 +105,42 @@ fn overrides() -> Overrides {
     }
 }
 
+/// Directory holding the WebKitGTK helper processes shipped in this bundle, or `None` outside an
+/// AppImage and when the bundle does not carry them.
+///
+/// The bundled WebKit resolves `WebKitNetworkProcess` and `WebKitWebProcess` through a path that is
+/// relative to the working directory rather than anchored to the bundle, so it finds them only when the
+/// process happens to start from a directory that contains a matching `lib/<arch>/webkit2gtk-<abi>/`
+/// tree. Callers pass the result to `WEBKIT_EXEC_PATH` to make the lookup independent of that.
+pub fn webkit_exec_path() -> Option<std::path::PathBuf> {
+    find_webkit_exec_path(std::path::Path::new(appdir()?))
+}
+
+/// Scan one bundle root for the helper directory. Split out from process state so it is testable.
+///
+/// The architecture triple and the WebKit ABI version are discovered rather than hard-coded, so the
+/// lookup survives a cross-architecture build and a `webkit2gtk-4.1` to `4.x` bump.
+fn find_webkit_exec_path(appdir: &std::path::Path) -> Option<std::path::PathBuf> {
+    // $APPDIR/usr/lib/<arch-triple>/webkit2gtk-<abi>/WebKitNetworkProcess
+    for arch in std::fs::read_dir(appdir.join("usr").join("lib")).ok()?.flatten() {
+        let Ok(entries) = std::fs::read_dir(arch.path()) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let dir = entry.path();
+            if dir
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with("webkit2gtk-"))
+                && dir.join("WebKitNetworkProcess").is_file()
+            {
+                return Some(dir);
+            }
+        }
+    }
+    None
+}
+
 /// Value a variable should have in a child process, with AppImage paths removed. `None` means the child
 /// must not receive it at all. Use this instead of `std::env::var` when building a child's environment.
 pub fn clean_var(key: &str) -> Option<String> {
@@ -253,5 +289,44 @@ mod tests {
             [("PATH".to_string(), "/usr/bin".to_string())].into_iter(),
         );
         assert!(o.is_empty());
+    }
+
+    /// Unique bundle root for the helper-lookup tests, which need real directories to scan. Removed
+    /// again by the test that creates it.
+    fn bundle_root(name: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("velaterm-{}-{}", name, std::process::id()));
+        std::fs::remove_dir_all(&dir).ok();
+        dir
+    }
+
+    /// The helpers sit under `usr/lib/<arch>/webkit2gtk-<abi>/`, the tree WebKit's own
+    /// working-directory-relative lookup misses. Neither the triple nor the ABI version is hard-coded,
+    /// so a value unlike the current build is used here on purpose.
+    #[test]
+    fn finds_bundled_webkit_helpers() {
+        let root = bundle_root("finds-helpers");
+        let helpers = root.join("usr/lib/aarch64-linux-gnu/webkit2gtk-4.2");
+        std::fs::create_dir_all(&helpers).unwrap();
+        std::fs::write(helpers.join("WebKitNetworkProcess"), b"").unwrap();
+        assert_eq!(find_webkit_exec_path(&root), Some(helpers));
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// A bundle without the helpers must yield nothing, so the caller leaves `WEBKIT_EXEC_PATH` unset
+    /// rather than pointing it at a directory that holds no helpers.
+    #[test]
+    fn ignores_directories_without_helpers() {
+        let root = bundle_root("ignores-empty");
+        std::fs::create_dir_all(root.join("usr/lib/x86_64-linux-gnu/webkit2gtk-4.1")).unwrap();
+        std::fs::create_dir_all(root.join("usr/lib/x86_64-linux-gnu/gio/modules")).unwrap();
+        assert_eq!(find_webkit_exec_path(&root), None);
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// Outside an AppImage there is no bundle to scan.
+    #[test]
+    fn finds_no_helpers_without_a_bundle() {
+        let root = bundle_root("no-bundle");
+        assert_eq!(find_webkit_exec_path(&root), None);
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -70,6 +70,22 @@ fn main() {
         if std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none() {
             std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
         }
+
+        // AppImage/WebKitGTK helper-process lookup: the bundled WebKit resolves WebKitNetworkProcess and
+        // WebKitWebProcess through a working-directory-relative path rather than one anchored to the
+        // bundle. A desktop launcher starts the app with the working directory set to $HOME or /, where
+        // that path resolves to nothing and startup aborts with "Unable to spawn a new child process";
+        // started from a shell sitting in /usr it instead finds the system helpers and silently pairs
+        // them with the bundled WebKit. Anchoring WEBKIT_EXEC_PATH to the bundle makes the correct
+        // helpers load from any working directory. Set it before WebKit initialization and only when the
+        // user has not supplied an override; outside an AppImage the lookup yields nothing and the
+        // system default applies.
+        #[cfg(target_os = "linux")]
+        if std::env::var_os("WEBKIT_EXEC_PATH").is_none() {
+            if let Some(dir) = velaterm_lib::appimage::webkit_exec_path() {
+                std::env::set_var("WEBKIT_EXEC_PATH", dir);
+            }
+        }
         let open_project = match velaterm_lib::open_project_from_args(
             &args,
             &std::env::current_dir().unwrap_or_default(),


### PR DESCRIPTION
## Problem

The Linux AppImage fails to start when launched from a desktop entry. No window appears and the process aborts with:

```
** (velaterm:22177): ERROR **: Unable to spawn a new child process: Failed to spawn child process
?././/lib/x86_64-linux-gnu/webkit2gtk-4.1/WebKitNetworkProcess? (No such file or directory)
```

## Cause

The bundled WebKitGTK resolves `WebKitNetworkProcess` and `WebKitWebProcess` through a path that is relative to the **working directory** (`./lib/<arch>/webkit2gtk-<abi>/`) rather than anchored to the bundle. The helpers actually ship at `$APPDIR/usr/lib/<arch>/webkit2gtk-<abi>/`, and `AppRun` exports `APPDIR`, `LD_LIBRARY_PATH` and `XDG_DATA_DIRS` but does not `chdir`, so the relative path is resolved against whatever directory the process was started in:

| Launched from | Working directory | Result |
| --- | --- | --- |
| Desktop launcher | `$HOME` or `/` | No match — startup aborts |
| Shell in `/usr` | `/usr` | Finds the **system** helpers |
| Shell elsewhere | varies | No match — startup aborts |

Note the middle row: where the host has `webkit2gtk` installed, the lookup silently pairs the system helper processes with the bundled WebKit library. That is why the failure looks intermittent rather than absolute, and why it can appear to work while running a mismatched pair.

Verified against the shipped `VelaTerm_0.1.100_amd64.AppImage` on Pop!_OS 24.04 (COSMIC/Wayland, XWayland). Setting `WEBKIT_EXEC_PATH` to the bundled helper directory makes it start correctly from any working directory, including `/`.

## Fix

Locate the helper directory under `$APPDIR` and export `WEBKIT_EXEC_PATH` before WebKit initializes, next to the existing `WEBKIT_DISABLE_DMABUF_RENDERER` workaround in `main.rs`:

- The lookup lives in `appimage.rs`, whose module doc already notes that WebKit's own processes *do* need the bundled paths — this makes that hold regardless of working directory.
- The architecture triple and the WebKit ABI version are discovered rather than hard-coded, so the lookup survives a cross-architecture build and a `webkit2gtk-4.1` → `4.x` bump.
- Applied only when the user has not already set `WEBKIT_EXEC_PATH`, matching the existing DMABUF override's behaviour.
- Outside an AppImage the lookup returns `None` and nothing changes; on non-Linux targets the call is compiled out.

`scripts/release.sh` (which writes the custom `AppRun`) is not in the public tree, so the equivalent one-line `export WEBKIT_EXEC_PATH=...` there was not an option from outside. Fixing it in `main.rs` also covers anyone running the binary directly from an extracted `AppDir`. If you would rather carry it in `AppRun`, this change can be dropped in favour of that.

## Tests

Three unit tests in `appimage.rs` cover the lookup: a bundle with helpers (using an architecture triple and ABI version deliberately unlike the current build, to prove neither is hard-coded), a bundle whose `webkit2gtk-*` directory holds no helper binary, and a root that is not a bundle at all.

Note on verification: the new code and its tests are compile-clean under `rustc --test -D warnings` and pass, but I was not able to build the full crate locally — the machine lacks `libwebkit2gtk-4.1-dev`/`libgtk-3-dev`, so `cargo test` cannot link the Tauri dependencies. Please let CI confirm the whole-crate build.
