### PR TITLE
Show the working tree's real changes in the Git tab (fixes #3)

### DIFF
--- a/src/components/diff/ChangesModal.tsx
+++ b/src/components/diff/ChangesModal.tsx
@@ -17,15 +17,7 @@ import {
 } from "../../ipc/commands";
 import { useTermStore } from "../../store/termStore";
 import { languageExtensionFor, vlxCmHighlighting } from "./codeMirrorTheme";
-
-/** Map status to a badge letter and color. */
-const STATUS_META: Record<string, { letter: string; color: string }> = {
-  added: { letter: "A", color: "var(--green, #3fb950)" },
-  modified: { letter: "M", color: "var(--yellow, #d29922)" },
-  deleted: { letter: "D", color: "var(--danger, #e05252)" },
-  untracked: { letter: "U", color: "var(--text-muted)" },
-  renamed: { letter: "R", color: "var(--cyan, #4aa)" },
-};
+import { statusMeta } from "./changeStatus";
 
 /** Render a single-file diff by loading both texts into a read-only MergeView, adding language support transparently once loaded. */
 function DiffView({ cwd, path }: { cwd: string; path: string }) {
@@ -212,7 +204,7 @@ export function ChangesModal() {
               </div>
             )}
             {files?.map((f) => {
-              const meta = STATUS_META[f.status] ?? STATUS_META.modified;
+              const meta = statusMeta(f.status);
               const active = f.path === selected;
               // Split into directory and filename. The directory may truncate with an ellipsis, while the filename
               // remains complete to preserve the most informative tail. Backend paths always use forward slashes

--- a/src/components/diff/changeStatus.ts
+++ b/src/components/diff/changeStatus.ts
@@ -1,0 +1,16 @@
+//! Badge presentation for a `ChangedFile` status, shared by the Changes modal and the right panel's
+//! Git tab so both render the same letter for the same status.
+
+/** Map status to a badge letter and color. */
+export const STATUS_META: Record<string, { letter: string; color: string }> = {
+  added: { letter: "A", color: "var(--green, #3fb950)" },
+  modified: { letter: "M", color: "var(--yellow, #d29922)" },
+  deleted: { letter: "D", color: "var(--danger, #e05252)" },
+  untracked: { letter: "U", color: "var(--text-muted)" },
+  renamed: { letter: "R", color: "var(--cyan, #4aa)" },
+};
+
+/** Badge for one status. Falls back to modified so a status added on the Rust side still renders. */
+export function statusMeta(status: string): { letter: string; color: string } {
+  return STATUS_META[status] ?? STATUS_META.modified;
+}

--- a/src/layout/RightPanel/GitTab.test.tsx
+++ b/src/layout/RightPanel/GitTab.test.tsx
@@ -1,0 +1,94 @@
+//! Regression tests for the Git tab's Changes section, which previously rendered a fixed design placeholder
+//! and so never reflected the working tree. The list must come from the backend and follow the tree as it
+//! changes: an edit, a stage, a commit or a branch switch all land here through the poll.
+
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { gitChangedFiles, getGitStatus } = vi.hoisted(() => ({
+  gitChangedFiles: vi.fn(),
+  getGitStatus: vi.fn(),
+}));
+
+vi.mock("../../ipc/commands", () => ({ gitChangedFiles }));
+vi.mock("../../ipc/info", () => ({ getGitStatus }));
+
+import { GitTab } from "./GitTab";
+
+function changed(path: string, status: string, additions = 0, deletions = 0, binary = false) {
+  return { path, status, additions, deletions, binary };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  getGitStatus.mockResolvedValue({ isRepo: true, branch: "main", ahead: 0, behind: 0 });
+  gitChangedFiles.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe("GitTab changes", () => {
+  /** The counts and paths must be the backend's, not a constant. A placeholder would show its own files here. */
+  it("renders the files and line counts reported by the backend", async () => {
+    gitChangedFiles.mockResolvedValue([
+      changed("src/main.rs", "modified", 3, 1),
+      changed("docs/new.md", "added", 12, 0),
+    ]);
+
+    render(<GitTab path="/repo" />);
+
+    expect(await screen.findByText("src/main.rs")).toBeDefined();
+    expect(screen.getByText("docs/new.md")).toBeDefined();
+    expect(screen.getByText("+3")).toBeDefined();
+    expect(screen.getByText("−1")).toBeDefined();
+    expect(gitChangedFiles).toHaveBeenCalledWith("/repo");
+  });
+
+  /** The reported failure: the panel kept its first render forever. A later poll must replace the list. */
+  it("picks up changes made after the first render", async () => {
+    gitChangedFiles.mockResolvedValue([changed("src/main.rs", "modified", 3, 1)]);
+    render(<GitTab path="/repo" />);
+    expect(await screen.findByText("src/main.rs")).toBeDefined();
+
+    // The working tree moves on: the edit is committed and a different file is touched.
+    gitChangedFiles.mockResolvedValue([changed("README.md", "modified", 1, 1)]);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+
+    expect(await screen.findByText("README.md")).toBeDefined();
+    expect(screen.queryByText("src/main.rs")).toBeNull();
+  });
+
+  /** A clean tree reports nothing, which must read as "no changes" rather than a stale list. */
+  it("shows the empty state for a clean working tree", async () => {
+    gitChangedFiles.mockResolvedValue([]);
+    render(<GitTab path="/repo" />);
+    expect(await screen.findByText("No changes")).toBeDefined();
+  });
+
+  /** Line counts do not exist for binary files: numstat reports `-` for both sides. */
+  it("omits line counts for binary files", async () => {
+    gitChangedFiles.mockResolvedValue([changed("logo.png", "added", 0, 0, true)]);
+    render(<GitTab path="/repo" />);
+    expect(await screen.findByText("logo.png")).toBeDefined();
+    expect(screen.queryByText("+0")).toBeNull();
+  });
+
+  /** Outside a repository the command rejects; the panel must stay empty rather than surface an error row. */
+  it("stays empty when the directory is not a repository", async () => {
+    gitChangedFiles.mockRejectedValue(new Error("Not a git repository: /tmp"));
+    render(<GitTab path="/tmp" />);
+    expect(await screen.findByText("No changes")).toBeDefined();
+  });
+
+  /** With no session there is nothing to query, so the backend must not be called at all. */
+  it("does not query the backend without a path", async () => {
+    render(<GitTab path={null} />);
+    await waitFor(() => expect(gitChangedFiles).not.toHaveBeenCalled());
+  });
+});

--- a/src/layout/RightPanel/GitTab.tsx
+++ b/src/layout/RightPanel/GitTab.tsx
@@ -1,21 +1,24 @@
-//! Right-panel Git tab: real branch/ahead-behind data plus design-placeholder per-file changes, extracted from RightPanel.
+//! Right-panel Git tab: branch/ahead-behind data and the working tree's per-file changes, extracted from RightPanel.
 //! The shared KV key-value row lives in parts.
 
 import { useEffect, useState } from "react";
+import { statusMeta } from "../../components/diff/changeStatus";
+import { useT } from "../../i18n";
+import { gitChangedFiles, type ChangedFile } from "../../ipc/commands";
 import { getGitStatus } from "../../ipc/info";
 import { type GitStatus as GitStatusType } from "../../types";
 import { KV } from "./parts";
-/* ===================== Git (real branch data + design-placeholder changes) ===================== */
+/* ===================== Git (branch data + working tree changes) ===================== */
 
-const PLACEHOLDER_CHANGES = [
-  { f: "src/lib/auth.ts", p: 18, m: 9, s: "M" },
-  { f: "src/lib/auth.test.ts", p: 44, m: 0, s: "A" },
-  { f: "src/components/Sidebar.tsx", p: 6, m: 2, s: "M" },
-  { f: "README.md", p: 7, m: 1, s: "M" },
-];
+/** A working tree changes from outside the app — an editor saving, `git add`, `git commit`, a branch
+ * switch — and none of those raise an event this panel can subscribe to, so the file list is polled.
+ * Matches the cadence the info tab uses for process stats. */
+const CHANGES_POLL_MS = 3000;
 
 export function GitTab({ path }: { path: string | null }) {
+  const t = useT();
   const [status, setStatus] = useState<GitStatusType | null>(null);
+  const [changes, setChanges] = useState<ChangedFile[]>([]);
 
   useEffect(() => {
     if (!path) {
@@ -31,6 +34,26 @@ export function GitTab({ path }: { path: string | null }) {
     };
   }, [path]);
 
+  useEffect(() => {
+    if (!path) {
+      setChanges([]);
+      return;
+    }
+    let cancelled = false;
+    // Outside a repository the command rejects; an empty list is the honest rendering either way.
+    const load = () => {
+      gitChangedFiles(path)
+        .then((f) => !cancelled && setChanges(f))
+        .catch(() => !cancelled && setChanges([]));
+    };
+    load();
+    const timer = setInterval(load, CHANGES_POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [path]);
+
   return (
     <div style={{ flex: 1, minHeight: 0, overflowY: "auto" }}>
       <div className="insp-section">
@@ -41,19 +64,38 @@ export function GitTab({ path }: { path: string | null }) {
           v={status?.isRepo ? `↑${status.ahead} ↓${status.behind}` : "—"}
         />
       </div>
-      {/* Placeholder from the design: the per-file change detail still needs the backend git diff. */}
       <div className="insp-section">
-        <h4>Changes · {PLACEHOLDER_CHANGES.length}</h4>
-        {PLACEHOLDER_CHANGES.map((c) => (
-          <div className="diffstat" key={c.f}>
-            <span className={"gb gb-" + c.s}>{c.s}</span>
-            <span className="fn">{c.f}</span>
-            <span className="n">
-              <span style={{ color: "var(--green)" }}>+{c.p}</span>{" "}
-              <span style={{ color: "var(--red)" }}>−{c.m}</span>
+        <h4>
+          {t("changes.title")} · {changes.length}
+        </h4>
+        {changes.length === 0 ? (
+          <div className="diffstat">
+            <span className="fn" style={{ color: "var(--text-muted)" }}>
+              {t("changes.noChanges")}
             </span>
           </div>
-        ))}
+        ) : (
+          changes.map((c) => {
+            const meta = statusMeta(c.status);
+            return (
+              <div className="diffstat" key={c.path}>
+                <span className={"gb gb-" + meta.letter}>{meta.letter}</span>
+                <span className="fn">{c.path}</span>
+                <span className="n">
+                  {/* Binary files have no line counts: numstat reports `-` for both sides. */}
+                  {c.binary ? (
+                    <span style={{ color: "var(--text-faint)" }}>—</span>
+                  ) : (
+                    <>
+                      <span style={{ color: "var(--green)" }}>+{c.additions}</span>{" "}
+                      <span style={{ color: "var(--red)" }}>−{c.deletions}</span>
+                    </>
+                  )}
+                </span>
+              </div>
+            );
+          })
+        )}
       </div>
     </div>
   );

--- a/src/styles/vlinx.css
+++ b/src/styles/vlinx.css
@@ -413,7 +413,7 @@ svg { display: block; }
 .file-row .ic { width: 16px; flex: none; display: grid; place-items: center; }
 .file-row .nm { flex: 1; overflow: hidden; text-overflow: ellipsis; }
 .file-row .gb { font-size: 9.5px; width: 14px; text-align: center; font-weight: 700; flex: none; }
-.gb-M { color: var(--yellow); } .gb-A { color: var(--green); } .gb-U { color: var(--text-faint); } .gb-D { color: var(--red); }
+.gb-M { color: var(--yellow); } .gb-A { color: var(--green); } .gb-U { color: var(--text-faint); } .gb-D { color: var(--red); } .gb-R { color: var(--cyan); }
 
 .insp-section { padding: 12px 14px; border-bottom: 1px solid var(--border); }
 .insp-section h4 { font-size: 10px; letter-spacing: 1px; text-transform: uppercase; color: var(--text-dim); font-weight: 600; margin-bottom: 10px; }


### PR DESCRIPTION
Fixes #3.

## Diagnosis

The panel is not going stale — it was never reading git. `GitTab.tsx` rendered `PLACEHOLDER_CHANGES`, a fixed four-entry array left over from the design:

```ts
const PLACEHOLDER_CHANGES = [
  { f: "src/lib/auth.ts", p: 18, m: 9, s: "M" },
  { f: "src/lib/auth.test.ts", p: 44, m: 0, s: "A" },
  { f: "src/components/Sidebar.tsx", p: 6, m: 2, s: "M" },
  { f: "README.md", p: 7, m: 1, s: "M" },
];
```

That is exactly the file list, status letters and counts quoted in #3, including the `· 4`. The existing comment says as much: *"Placeholder from the design: the per-file change detail still needs the backend git diff."*

The Branch/upstream section directly above it **is** real, which is what made the placeholder read as a working panel showing stale data rather than as an unimplemented one. Worth noting for anyone triaging: the Changes **modal** has always shown real data, so the two disagreed.

## Change

The backend already exists and already serves the modal — `git::changed_files()` returns `path`, `status`, `additions`, `deletions` and `binary` per file via the `git_changed_files` command — so this is wiring rather than new plumbing:

- Fetch through `gitChangedFiles(path)` and poll it. A working tree changes from outside the app (an editor saving, `git add`, `git commit`, a branch switch) with no event to subscribe to, so polling is the available mechanism; the 3s cadence matches the info tab's process stats. Happy to switch this to a filesystem watcher if you would prefer one — it seemed a larger change than this fix warranted.
- Move the status-to-badge mapping into `components/diff/changeStatus.ts`, shared by the modal and the tab so they cannot drift. Importing it from `ChangesModal` directly would have pulled CodeMirror into the right panel's bundle.
- Add `.gb-R` to the badge colors — it was missing, so renamed files rendered unstyled.
- Show an em dash rather than `+0 −0` for binary files, whose `numstat` carries no line counts.
- Empty and non-repository directories both render `changes.noChanges` instead of a stale list.

Strings go through i18n; `changes.title` and `changes.noChanges` already existed.

## Tests

Six tests in `GitTab.test.tsx`, mocking the IPC layer:

| Test | Covers |
| --- | --- |
| renders backend files and counts | The data is the backend's, not a constant |
| picks up changes after first render | The reported symptom in #3 |
| empty state for a clean tree | No stale list when nothing is changed |
| omits line counts for binary files | `numstat` has no counts to show |
| stays empty outside a repository | The command rejects; no error row |
| no query without a path | No session, no call |

Full suite passes (176 tests, 25 files), `tsc --noEmit` clean, `eslint` clean.
