### PR TITLE
fix: let a clean checkout run the dev build

### DIFF
--- a/scripts/dev-desktop.sh
+++ b/scripts/dev-desktop.sh
@@ -29,9 +29,17 @@ source "$(dirname "$0")/dev-lib.sh"
 case "$(uname -s)" in
   MINGW*|MSYS*|CYGWIN*)
     if [ ! -f src-tauri/resources/gitbash/usr/bin/bash.exe ]; then
-      echo "==> resources/gitbash is empty, fetching the minimal Git Bash first (fetch-gitbash.ps1)"
-      powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/fetch-gitbash.ps1 \
-        || { echo "✗ fetch-gitbash failed, aborting" >&2; exit 1; }
+      if [ -f scripts/fetch-gitbash.ps1 ]; then
+        echo "==> resources/gitbash is empty, fetching the minimal Git Bash first (fetch-gitbash.ps1)"
+        powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/fetch-gitbash.ps1 \
+          || { echo "✗ fetch-gitbash failed, aborting" >&2; exit 1; }
+      else
+        # The bundled Git Bash is a packaging input, not a build input: the dev window runs fine without it.
+        # Aborting here makes `pnpm dev:desktop` unusable on Windows whenever the fetch script is unavailable,
+        # so degrade to a warning and let the developer decide.
+        echo "==> scripts/fetch-gitbash.ps1 not found; continuing without the bundled Git Bash." >&2
+        echo "    Windows' bundled default-shell option will be unavailable in this dev build." >&2
+      fi
     fi ;;
 esac
 

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -35,6 +35,15 @@ fn main() {
     // refresh automatically. Full `cargo build` and release paths always produce a fresh value.
     println!("cargo:rerun-if-changed=../.git/HEAD");
 
+    // Ensure ../dist exists before anything resolves it. `rust_embed::Embed` in `web` resolves its `#[folder]`
+    // at COMPILE time and fails the whole crate when the directory is absent, which is the state of every fresh
+    // clone until the frontend has been built once. `beforeDevCommand` is `pnpm dev` — a dev server that never
+    // writes `dist/` — so `tauri dev` cannot bootstrap a clean checkout without this. Creating the directory is
+    // enough; its contents are not needed here, because debug builds read it from disk at runtime and release
+    // builds populate it through `beforeBuildCommand`. Best-effort: a failure here is not worth blocking a build
+    // that may not need the directory at all.
+    let _ = std::fs::create_dir_all("../dist");
+
     // Run tauri-build only for GUI builds. It parses tauri.conf.json, requires frontendDist (../dist), and
     // generates permission scaffolding for generate_context!. The minimal server (`--no-default-features`) does
     // not call generate_context! or need frontend output; skipping this step allows builds without ../dist.


### PR DESCRIPTION
A fresh clone cannot run `pnpm dev:desktop`. There are two independent causes; both reproduced on Windows 11 today at `d098f5a`.

### 1. `rust_embed` fails the crate when `../dist` is absent

`src-tauri/src/web/mod.rs` derives `Embed` with `#[folder = "../dist"]`, which is resolved at **compile** time. On a clean clone the directory does not exist yet, so every `Assets::get(...)` call fails to compile:

```
error[E0599]: no function or associated item named `get` found for struct `web::Assets` in the current scope
   --> src\web\mod.rs:512:19
error: could not compile `velaterm` (lib) due to 3 previous errors
```

`beforeDevCommand` is `pnpm dev`, a dev server that never writes `dist/`, so today only a prior `pnpm build` makes the crate compile.

`build.rs` now creates the directory before anything resolves it. Its *contents* are not needed here — debug builds read it from disk at runtime, and release builds populate it through `beforeBuildCommand` — so an empty directory is sufficient in both cases. The call is best-effort and never blocks a build that doesn't need it.

### 2. `dev-desktop.sh` aborts on the unpublished `fetch-gitbash.ps1`

`scripts/fetch-gitbash.ps1` isn't part of the public repository, so on Windows the guard exits before anything builds:

```
==> resources/gitbash is empty, fetching the minimal Git Bash first (fetch-gitbash.ps1)
The argument 'scripts/fetch-gitbash.ps1' to the -File parameter does not exist.
x fetch-gitbash failed, aborting
```

The bundled Git Bash is a packaging input rather than a build input — the dev window runs fine without it, only the bundled default-shell option is unavailable. The guard now degrades to a warning when the fetch script is missing and lets the developer decide.

**Behaviour is unchanged when the script is present:** a failing fetch still aborts.

### Verification

- With `dist/` removed to reproduce the clean-clone state, `cargo build` succeeds and recreates it (1m42s).
- The guard was exercised in both branches: exit 0 with a warning when the script is absent, exit 1 when it is present and fails.

### Notes

- **No changelog entry.** `docs/changelog.md` is organised by released version in user-facing terms, and these are developer-tooling changes with no user-visible effect. Glad to add one if you'd rather.
- **Local checks.** `pnpm lint` is clean (exit 0, no output) and `tsc --noEmit` is clean with these commits applied. `pnpm test` gives the same results as with them stashed.
  Note for anyone reading an earlier revision of this: I originally wrote that lint gave "the same results" as `main`, when `main` still carried two `ConnectionBanner.tsx` errors. v0.1.102 fixed those, so the bar is now zero and this branch meets it. The old phrasing was true when written but implied failures that no longer exist.
- Kept as two commits so they can be taken separately — the `build.rs` fix applies to every platform, the shell change only to Windows.

