### PR TITLE
fix: keep color-scheme in sync with the selected theme

### DIFF
--- a/src/theme.test.ts
+++ b/src/theme.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// applyTheme pushes the resolved palette into the live terminal registry; stub it so the module can be
+// exercised without any xterm instances.
+vi.mock("./terminal/registry", () => ({ setXtermTheme: vi.fn() }));
+
+import { applyTheme } from "./theme";
+
+/** jsdom has no matchMedia; report the OS as the given scheme so 'system' resolves predictably. */
+function mockSystemScheme(scheme: "dark" | "light") {
+  vi.stubGlobal("matchMedia", (query: string) => ({
+    matches: query.includes("dark") === (scheme === "dark"),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }));
+}
+
+describe("applyTheme", () => {
+  beforeEach(() => {
+    document.documentElement.removeAttribute("style");
+    document.documentElement.removeAttribute("data-theme");
+    localStorage.clear();
+  });
+
+  // color-scheme decides how the user agent paints native in-page controls. index.html seeds it from
+  // prefers-color-scheme, so an explicit theme must override it or native checkboxes, selects, and
+  // scrollbars keep following the OS while the rest of the app switches.
+  it.each(["dark", "light"] as const)("sets data-theme and color-scheme to %s", (mode) => {
+    mockSystemScheme(mode === "dark" ? "light" : "dark"); // opposite OS scheme: the explicit mode must win
+    applyTheme(mode);
+    expect(document.documentElement.dataset.theme).toBe(mode);
+    expect(document.documentElement.style.getPropertyValue("color-scheme")).toBe(mode);
+  });
+
+  it("resolves 'system' to the OS scheme", () => {
+    mockSystemScheme("dark");
+    applyTheme("system");
+    expect(document.documentElement.dataset.theme).toBe("dark");
+    expect(document.documentElement.style.getPropertyValue("color-scheme")).toBe("dark");
+    expect(localStorage.getItem("vlx-theme")).toBe("system"); // the mode persists, not the resolved scheme
+  });
+});

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -148,10 +148,15 @@ function syncNativeChrome(mode: ThemeMode) {
   });
 }
 
-/** Apply a scheme: resolve it, write data-theme, persist the mode, and synchronize xterm colors. */
+/** Apply a scheme: resolve it, write data-theme and color-scheme, persist the mode, and synchronize xterm colors. */
 export function applyTheme(mode: ThemeMode) {
   const resolved = resolveTheme(mode);
   document.documentElement.dataset.theme = resolved;
+  // color-scheme drives how the user agent renders native in-page controls: checkboxes, radios, selects,
+  // scrollbars, and form fields. index.html only seeds it from prefers-color-scheme, so without this line it
+  // keeps following the OS for the window's lifetime and an explicit dark theme still draws light checkboxes
+  // on a light-mode system. 'system' mode stays live because the media-query watcher re-runs applyTheme.
+  document.documentElement.style.colorScheme = resolved;
   localStorage.setItem(STORAGE_KEY, mode);
   setXtermTheme(XTERM_THEME[resolved]);
   syncNativeChrome(mode);


### PR DESCRIPTION
## Problem

`applyTheme()` writes `data-theme` onto `documentElement`, but never updates `color-scheme`. `index.html` seeds that property once, from the OS:

```html
:root { color-scheme: dark; }
@media (prefers-color-scheme: light) { :root { color-scheme: light; } }
```

Since nothing updates it afterwards, the seeded value sticks for the window's lifetime. Choosing a theme that disagrees with the OS therefore leaves every native in-page control — checkboxes, radios, selects, scrollbars, form fields — painted in the OS scheme while the rest of the UI switches.

Easiest repro, on a dark-mode OS: pick **Light** in the titlebar theme selector, then quit. The "save workspace" checkbox in the quit dialog is still dark, on an otherwise light dialog.

## Fix

Set `documentElement.style.colorScheme` alongside `data-theme`. The inline style outranks the `:root` rule in `index.html`, and `system` mode keeps tracking the OS because `watchSystemTheme` → `applyAppearance` already re-runs `applyTheme` on change.

## Verification

- Confirmed by hand on Windows (WebView2), in both directions: dark → light and light → dark, the native checkbox follows the app.
- Adds `src/theme.test.ts` covering both explicit modes and `system`. Reverting the one-line change makes all three tests fail, so they measure the defect rather than the code.
- `tsc --noEmit` is clean.
- `eslint .` is clean (exit 0, no output) and `tsc --noEmit` is clean. Both were measured after rebasing onto v0.1.102, which fixed the two `ConnectionBanner.tsx` errors that `main` used to carry — so the lint bar is zero now and this meets it, rather than merely matching a red baseline as an earlier revision of this text said.
- The remaining `vitest` failures on my Windows box are 5s timeouts rather than assertion failures, and reproduce without this branch; the count varies run to run, so they are load-dependent on that machine, not caused here.

