### PR TITLE
fix: stop NO_COLOR leaking from the app environment into every PTY

### DIFF
--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -383,6 +383,11 @@ impl PtyManager {
         // rewrite of `PYTHONHOME`, `LD_LIBRARY_PATH`, `PATH`, and friends. Undo it before anything else so
         // the user's shell sees the system environment and later overrides here still win. No-op elsewhere.
         crate::appimage::scrub_pty(&mut cmd);
+        // This process's environment reaches every PTY, so a NO_COLOR inherited from whatever launched the
+        // app — an agent session, a CI shell, a login profile — would silently make every shell and TUI here
+        // render monochrome while the next two lines advertise 24-bit color. Drop it so the environment agrees
+        // with the capability being advertised; per-command opt-out still works from inside the terminal.
+        cmd.env_remove("NO_COLOR");
         // Advertise a color-capable terminal.
         cmd.env("TERM", "xterm-256color");
         // Explicitly advertise true color so applications do not conservatively fall back to 256 colors.


### PR DESCRIPTION
Addresses item 1 of #26.

## Problem

A PTY inherits this process's environment. If the app was launched from a shell that exports `NO_COLOR` — an agent session, a CI-like shell, someone's login profile — every terminal and TUI inside the app inherits it and renders monochrome.

What makes it a bug rather than a preference is that `pty/manager.rs` contradicts itself three lines apart:

```rust
crate::appimage::scrub_pty(&mut cmd);
cmd.env("TERM", "xterm-256color");     // "I am color-capable"
cmd.env("COLORTERM", "truecolor");     // "in fact, 24-bit"
```

It advertises 24-bit color while passing the child a variable whose entire meaning is *emit none*.

## Fix

`cmd.env_remove("NO_COLOR")`, placed beside the existing AppImage environment scrub — the slot already meant for undoing inherited pollution — and before the capability variables, so later overrides still win.

## Verification

Launched the dev build on Windows with `NO_COLOR=1` in its own environment, then read a fresh tab:

| | before | after |
|---|---|---|
| `NO_COLOR` | `1` | *(empty)* |
| `TERM` | `xterm-256color` | `xterm-256color` |
| `COLORTERM` | `truecolor` | `truecolor` |

A syntax-highlighting tool went from monochrome to colored in the same tab, with no `env -u` workaround. The parent process still had `NO_COLOR=1` throughout, so this exercises the strip rather than the absence of the variable.

`cargo fmt --check` reports the same drift on this file with and without the change (140 lines either way), so nothing is added there.

No unit test: the environment setup sits inside the spawn function, and making it directly testable would mean extracting a pure helper — a refactor beyond this fix. That matches the existing pattern in `appimage.rs`, whose tests cover the pure `compute()` rather than the `CommandBuilder`.

## Scope, and a question

#26 also asks to scrub `FORCE_COLOR=0`, `CI`, and `TERM=dumb`. This PR deliberately does only `NO_COLOR`:

- `TERM=dumb` is **already** neutralised — `cmd.env("TERM", "xterm-256color")` overrides it unconditionally.
- `FORCE_COLOR=0` is the same class of problem, but removing the variable outright would also discard a deliberate `FORCE_COLOR=1`, so it wants a value check rather than a blind removal.
- `CI` is read by tools for more than color — non-interactive prompts, progress rendering — so stripping it could surprise people in ways color-only variables do not.

Happy to add any of those here or in a follow-up, whichever you prefer.

One open design question worth your call: should the strip be unconditional, as here? My reasoning is that a GUI app's inherited environment reflects *how it was launched* rather than a per-terminal choice, so it is weak evidence of intent. But someone who exports `NO_COLOR` globally for accessibility reasons has a fair claim to the opposite, and that would argue for a setting instead.
