### PR TITLE
fix: keep the quit dialog's saved answer from being reverted on next launch

### DIFF
--- a/src/components/QuitConfirmModal.test.tsx
+++ b/src/components/QuitConfirmModal.test.tsx
@@ -4,7 +4,8 @@
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { quit, store } = vi.hoisted(() => ({
+const { flushNow, quit, store } = vi.hoisted(() => ({
+  flushNow: vi.fn().mockResolvedValue(undefined),
   quit: {
     onRequested: vi.fn(),
     ack: vi.fn().mockResolvedValue(undefined),
@@ -20,6 +21,7 @@ const { quit, store } = vi.hoisted(() => ({
 
 vi.mock("../i18n", () => ({ useT: () => (key: string) => key }));
 vi.mock("../platform", () => ({ platform: { quit } }));
+vi.mock("../ipc/settingsSync", () => ({ flushNow }));
 vi.mock("../hooks/nativeViewSuspend", () => ({ useSuspendNativeViews: () => {} }));
 vi.mock("../store/termStore", () => {
   const useTermStore = (selector: (s: typeof store) => unknown) => selector(store);
@@ -42,6 +44,12 @@ beforeEach(() => {
 });
 
 afterEach(cleanup);
+
+/** Approve the exit and let confirm()'s awaited settings flush settle before asserting. */
+async function confirmExit() {
+  fireEvent.click(screen.getByText("quit.confirm"));
+  await waitFor(() => expect(quit.confirm).toHaveBeenCalled());
+}
 
 /** Render and drive the shell request so the dialog is on screen. */
 async function open() {
@@ -74,7 +82,7 @@ describe("QuitConfirmModal", () => {
 
   it("exits without saving when the box is unticked", async () => {
     await open();
-    fireEvent.click(screen.getByText("quit.confirm"));
+    await confirmExit();
     expect(store.saveWorkspaceSnapshot).not.toHaveBeenCalled();
     expect(quit.confirm).toHaveBeenCalled();
   });
@@ -82,7 +90,7 @@ describe("QuitConfirmModal", () => {
   it("writes the snapshot before approving the exit when ticked", async () => {
     await open();
     fireEvent.click(screen.getByRole("checkbox"));
-    fireEvent.click(screen.getByText("quit.confirm"));
+    await confirmExit();
 
     expect(store.saveWorkspaceSnapshot).toHaveBeenCalled();
     expect(quit.confirm).toHaveBeenCalled();
@@ -95,8 +103,44 @@ describe("QuitConfirmModal", () => {
   it("remembers the choice as the next exit's default", async () => {
     await open();
     fireEvent.click(screen.getByRole("checkbox"));
-    fireEvent.click(screen.getByText("quit.confirm"));
+    await confirmExit();
     expect(store.setSaveWorkspaceOnQuit).toHaveBeenCalledWith(true);
+  });
+
+  // Settings writes are debounced by 400 ms and the process dies well inside that window. Startup
+  // reconciliation then treats the backend as authoritative, so an unflushed answer is not merely lost:
+  // it overwrites the value already in localStorage, and the box comes back unticked every launch.
+  it("flushes the remembered choice to the backend before approving the exit", async () => {
+    await open();
+    fireEvent.click(screen.getByRole("checkbox"));
+    await confirmExit();
+
+    expect(flushNow).toHaveBeenCalled();
+    expect(flushNow.mock.invocationCallOrder[0]).toBeGreaterThan(
+      store.setSaveWorkspaceOnQuit.mock.invocationCallOrder[0],
+    );
+    expect(flushNow.mock.invocationCallOrder[0]).toBeLessThan(
+      quit.confirm.mock.invocationCallOrder[0],
+    );
+  });
+
+  // Call order alone does not prove the fix: a fire-and-forget `flushNow()` satisfies every assertion above
+  // while still racing termination, which is the whole bug. Hold the flush unresolved and require that the
+  // exit stays unapproved until it lands, so dropping the await fails here.
+  it("does not approve the exit until the flush has landed", async () => {
+    let landFlush: () => void = () => {};
+    flushNow.mockImplementationOnce(
+      () => new Promise<void>((resolve) => { landFlush = resolve; }),
+    );
+    await open();
+    fireEvent.click(screen.getByRole("checkbox"));
+    fireEvent.click(screen.getByText("quit.confirm"));
+
+    await waitFor(() => expect(flushNow).toHaveBeenCalled());
+    expect(quit.confirm).not.toHaveBeenCalled();
+
+    await act(async () => landFlush());
+    await waitFor(() => expect(quit.confirm).toHaveBeenCalled());
   });
 
   it("preticks the box from the remembered preference", async () => {

--- a/src/components/QuitConfirmModal.tsx
+++ b/src/components/QuitConfirmModal.tsx
@@ -10,6 +10,7 @@
 
 import { useEffect, useState } from "react";
 import { useT } from "../i18n";
+import { flushNow } from "../ipc/settingsSync";
 import { platform } from "../platform";
 import { useTermStore } from "../store/termStore";
 import { Backdrop } from "./Backdrop";
@@ -51,8 +52,14 @@ export function QuitConfirmModal() {
     void platform.quit.cancel();
   };
 
-  const confirm = () => {
+  const confirm = async () => {
     setSaveWorkspaceOnQuit(save);
+    // Force the checkbox answer to the backend before approving the exit. Settings writes are debounced by
+    // 400 ms, and the process dies well inside that window, so the backend would keep the previous value.
+    // Startup reconciliation treats the backend as authoritative and overwrites the local copy from it, which
+    // means a skipped flush does not merely fail to save the answer -- it silently reverts the one already
+    // written to localStorage, and the checkbox comes back unticked every launch.
+    await flushNow();
     // Write the snapshot before approving the exit; the shell terminates the process as soon as confirm resolves.
     if (save) saveWorkspaceSnapshot();
     setAsking(false);
@@ -148,7 +155,7 @@ export function QuitConfirmModal() {
           </button>
           <button
             autoFocus
-            onClick={confirm}
+            onClick={() => void confirm()}
             style={{
               padding: "7px 16px",
               border: "none",


### PR DESCRIPTION
## The bug

Tick "save workspace", confirm the exit, relaunch — the box is unticked again.

It is a race with process termination, and the damage is worse than a lost write. `setSaveWorkspaceOnQuit` reaches localStorage synchronously, but `pushSetting` debounces the **backend** write by 400 ms (`ipc/settingsSync.ts`), and `confirm_quit` kills the process well inside that window. At the next launch `reconcileSettings` treats the backend as authoritative and overwrites any differing local value. So the skipped flush does not merely fail to save the answer — **it reverts the copy already written to localStorage.**

**This is not specific to the checkbox.** Any setting changed in the last 400 ms before the process dies is reverted the same way. The quit dialog is simply the one place where a write is always immediately followed by termination, which is why it reproduces every time.

## The fix

`await flushNow()` before approving the exit. That function is already exported for exactly this case and already used this way elsewhere — `TerminalView.tsx` calls it after filling an agent path, with a comment noting the backend spawn would otherwise read the pre-debounce value. This is the same hazard in a place where it is fatal rather than merely stale.

## Tests

Two cases, and the distinction between them is the point:

1. Call ordering — the flush happens after the answer is recorded and before the exit is approved.
2. **The flush is held unresolved, and the exit must stay unapproved until it lands.**

Only the second actually pins the `await`. I checked this rather than assumed it: with `await flushNow()` weakened to `void flushNow()`, every call-order assertion still passes, because a fire-and-forget call preserves ordering while still racing termination — the original bug, undetected. The second test fails on exactly that mutation.

Verified on Windows against `v0.1.102`: `tsc --noEmit` clean, `eslint .` clean, the file's 9 tests pass, and the await-sensitive test fails when the await is removed.

## Credit

Found and fixed by another contributor working on this fork — the diagnosis, the fix and the first test are theirs. I rebased it onto `v0.1.102`, added the await-sensitive test, and am opening the PR.
