### PR TITLE
fix(windows): stop mangling agent arguments under PowerShell 7

### DIFF
--- a/src-tauri/src/agent/inject.rs
+++ b/src-tauri/src/agent/inject.rs
@@ -1721,7 +1721,13 @@ mod tests {
             shell_kind("C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"),
             ShellKind::PowerShell
         );
-        assert_eq!(shell_kind("pwsh"), ShellKind::PowerShell);
+        // The two dialects are separate variants: they pass native-command arguments under opposite
+        // rules, so anything that collapses them reintroduces the --settings mangling on pwsh 7.
+        assert_eq!(shell_kind("pwsh"), ShellKind::Pwsh);
+        assert_eq!(
+            shell_kind("C:\\Program Files\\PowerShell\\7\\pwsh.exe"),
+            ShellKind::Pwsh
+        );
         assert_eq!(shell_kind("C:\\Windows\\System32\\cmd.exe"), ShellKind::Cmd);
     }
 

--- a/src-tauri/src/agent/inject.rs
+++ b/src-tauri/src/agent/inject.rs
@@ -10,6 +10,9 @@
 use crate::agent::server::HookEndpoint;
 use crate::models::SessionKind;
 
+#[cfg(test)]
+mod powershell_tests;
+
 /// Holds the Claude settings JSON so the command line can reference it without echoing a large JSON value.
 pub const CLAUDE_SETTINGS_ENV: &str = "VLX_CLAUDE_SETTINGS";
 /// Holds the Codex notify array referenced by `-c notify=`.
@@ -66,11 +69,11 @@ pub enum ShellKind {
     /// POSIX shells such as bash, zsh, sh, and dash.
     Posix,
     Fish,
-    /// Windows PowerShell 5.1 (`powershell.exe`), which passes native-command arguments through
-    /// unmodified and therefore needs quotes escaped by hand.
+    /// Windows PowerShell 5.1 (`powershell.exe`), whose Legacy native argument binding requires
+    /// manually escaped quotes in structured values.
     PowerShell,
-    /// PowerShell 6+ (`pwsh`), which re-quotes native-command arguments itself. Hand-escaping a value
-    /// here double-escapes it, so the two dialects need opposite treatment; see [`value_ref`].
+    /// PowerShell Core (`pwsh`). Native argument passing depends on the version, runtime preference,
+    /// and target command; the launcher checks those after the interactive profile has loaded.
     Pwsh,
     Cmd,
 }
@@ -242,9 +245,12 @@ pub(crate) fn value_ref(shell: ShellKind, env: &str) -> String {
     match shell {
         ShellKind::Posix | ShellKind::Fish => format!("\"${env}\""),
         ShellKind::PowerShell => format!("$($env:{env} -replace '\"', '\\\"')"),
-        // pwsh re-quotes the argument itself, so the value is passed as-is; escaping here would
-        // reach the agent as literal backslashes and produce the very error the arm above prevents.
-        ShellKind::Pwsh => format!("\"$env:{env}\""),
+        // The scoped Pwsh launcher decides whether the native binder uses Legacy rules. Modern
+        // binding preserves the raw value. Legacy binding also consumes backslashes before quotes,
+        // so preserve those when escaping JSON strings such as Windows paths and quoted text.
+        ShellKind::Pwsh => format!(
+            r#""$(if ($vlxLegacyArguments) {{ $env:{env} -replace '(\\*)"', '$1$1\"' }} else {{ $env:{env} }})""#
+        ),
         ShellKind::Cmd => format!("\"%{env}%\""),
     }
 }
@@ -641,6 +647,7 @@ fn launch_cmd(shell: ShellKind, bin: &str, args: &str) -> String {
     } else {
         format!("{bin} {args}")
     };
+    let inner = pwsh_invocation(shell, bin, &inner);
     // The `else` branch reports through the hook and prints a readable message.
     let report = report_not_found(shell, bin);
     // Clear the screen and scrollback before the guard to remove the shell's echoed command.
@@ -675,6 +682,42 @@ fn sq_posix(s: &str) -> String {
 /// Embeds arbitrary text in PowerShell single quotes by replacing `'` with `''`.
 fn sq_pwsh(s: &str) -> String {
     s.replace('\'', "''")
+}
+
+/// Chooses native argument passing inside the actual interactive Pwsh session. A separate version
+/// probe cannot see profile preferences or aliases. The child scope keeps our variables local and
+/// leaves PSNativeCommandArgumentPassing unchanged, including for user-supplied launch arguments.
+fn pwsh_invocation(shell: ShellKind, target: &str, inner: &str) -> String {
+    if shell != ShellKind::Pwsh {
+        return inner.to_string();
+    }
+    let target = sq_pwsh(target);
+    // The feature was experimental in 7.2 and became stable in 7.3. A missing preference in a
+    // capable engine means Standard, whereas older engines always use Legacy. Windows mode uses
+    // Legacy for the same command names and extensions as PowerShell's NativeCommandProcessor.
+    format!(
+        "& {{ \
+         $vlxArgumentMode = 'Legacy'; \
+         if ($PSVersionTable.PSVersion -ge [version]'7.3' -or \
+             ($PSVersionTable.PSVersion -ge [version]'7.2' -and \
+              $EnabledExperimentalFeatures -contains 'PSNativeCommandArgumentPassing')) {{ \
+             $vlxArgumentMode = [string](Get-Variable -Name PSNativeCommandArgumentPassing \
+                 -ValueOnly -ErrorAction SilentlyContinue); \
+         }}; \
+         $vlxLegacyArguments = $vlxArgumentMode -eq 'Legacy'; \
+         if ($vlxArgumentMode -eq 'Windows') {{ \
+             $vlxCommand = $ExecutionContext.InvokeCommand.GetCommand(\
+                 '{target}', [System.Management.Automation.CommandTypes]::All); \
+             if ($vlxCommand -is [System.Management.Automation.AliasInfo]) {{ \
+                 $vlxCommand = $vlxCommand.ResolvedCommand; \
+             }}; \
+             if ($vlxCommand -is [System.Management.Automation.ApplicationInfo]) {{ \
+                 $vlxLegacyArguments = \
+                     [System.IO.Path]::GetExtension($vlxCommand.Path) -in '.bat','.cmd','.js','.vbs','.wsf' -or \
+                     [System.IO.Path]::GetFileNameWithoutExtension($vlxCommand.Path) -in 'cmd','cscript','find','sqlcmd','wscript'; \
+             }}; \
+         }}; {inner} }}"
+    )
 }
 
 /// Escapes bare text used as an `echo` argument inside a cmd.exe parenthesized block. Prefixing block-level
@@ -729,6 +772,7 @@ fn launch_cmd_at(shell: ShellKind, path: &str, args: &str) -> String {
             } else {
                 format!("& '{p}' {args}")
             };
+            let inner = pwsh_invocation(shell, path, &inner);
             let report = report_not_found_with(shell, &sq_pwsh(&path_missing_message(path)));
             format!(
                 "{clear}if (Test-Path -LiteralPath '{p}' -PathType Leaf) {{ {inner} }} else {{ {report} }}"
@@ -1501,11 +1545,7 @@ mod tests {
         assert!(bare.contains("\"$VLX_NOTFOUND_URL\""));
     }
 
-    /// `pwsh` and `powershell.exe` need OPPOSITE escaping for a native-command argument, so they must not
-    /// classify to the same kind. Windows PowerShell passes the value through verbatim and needs every `"`
-    /// hand-escaped; pwsh re-quotes the argument itself, so that same escaping arrives as literal
-    /// backslashes and the agent reports `Invalid JSON provided to --settings`. Both behaviours were
-    /// measured on Windows against 5.1.26100 and 7.6.5.
+    /// Keep the runtime-aware Pwsh launcher separate from the Windows PowerShell 5.1 path.
     #[test]
     fn shell_kind_separates_windows_powershell_from_pwsh() {
         assert_eq!(
@@ -1520,25 +1560,20 @@ mod tests {
         assert_eq!(shell_kind("powershell"), ShellKind::PowerShell);
     }
 
-    /// The regression this fix exists for: a compact-JSON value must reach the agent unmangled on BOTH
-    /// PowerShell dialects, and that requires different text in each.
+    /// Pwsh chooses escaping at launch time instead of assuming its native argument mode from its name.
     #[test]
-    fn value_ref_escapes_for_windows_powershell_but_not_for_pwsh() {
-        // Windows PowerShell 5.1 hand-escapes, because it passes the value through untouched.
+    fn value_ref_defers_pwsh_escaping_to_the_runtime_mode() {
+        // Retain the existing Windows PowerShell 5.1 quote-escaping expression.
         assert_eq!(
             value_ref(ShellKind::PowerShell, "VLX_CLAUDE_SETTINGS"),
             r#"$($env:VLX_CLAUDE_SETTINGS -replace '"', '\"')"#
         );
-        // pwsh must NOT hand-escape; a backslash here survives into the argument itself.
-        assert_eq!(
-            value_ref(ShellKind::Pwsh, "VLX_CLAUDE_SETTINGS"),
-            r#""$env:VLX_CLAUDE_SETTINGS""#
-        );
-        assert!(!value_ref(ShellKind::Pwsh, "X").contains('\\'));
+        let reference = value_ref(ShellKind::Pwsh, "VLX_CLAUDE_SETTINGS");
+        assert!(reference.contains("if ($vlxLegacyArguments)"));
+        assert!(reference.contains("else { $env:VLX_CLAUDE_SETTINGS }"));
     }
 
-    /// A prompt is one argument on both dialects. Windows PowerShell still splits a prompt containing `"`
-    /// (a pre-existing limitation noted on `prompt_ref`); pwsh does not, so quoting is enough for both.
+    /// Preserve prompt references; Legacy-mode prompt quoting is independent of structured values.
     #[test]
     fn prompt_ref_quotes_on_both_powershell_dialects() {
         assert_eq!(
@@ -1721,8 +1756,7 @@ mod tests {
             shell_kind("C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"),
             ShellKind::PowerShell
         );
-        // The two dialects are separate variants: they pass native-command arguments under opposite
-        // rules, so anything that collapses them reintroduces the --settings mangling on pwsh 7.
+        // Pwsh needs runtime argument-mode detection, unlike the Windows PowerShell 5.1 path.
         assert_eq!(shell_kind("pwsh"), ShellKind::Pwsh);
         assert_eq!(
             shell_kind("C:\\Program Files\\PowerShell\\7\\pwsh.exe"),

--- a/src-tauri/src/agent/inject.rs
+++ b/src-tauri/src/agent/inject.rs
@@ -66,7 +66,12 @@ pub enum ShellKind {
     /// POSIX shells such as bash, zsh, sh, and dash.
     Posix,
     Fish,
+    /// Windows PowerShell 5.1 (`powershell.exe`), which passes native-command arguments through
+    /// unmodified and therefore needs quotes escaped by hand.
     PowerShell,
+    /// PowerShell 6+ (`pwsh`), which re-quotes native-command arguments itself. Hand-escaping a value
+    /// here double-escapes it, so the two dialects need opposite treatment; see [`value_ref`].
+    Pwsh,
     Cmd,
 }
 
@@ -79,7 +84,9 @@ pub fn shell_kind(path: &str) -> ShellKind {
         .to_ascii_lowercase();
     // Ignore the `.exe` suffix on Windows.
     let base = base.strip_suffix(".exe").unwrap_or(&base);
-    if base.contains("powershell") || base.contains("pwsh") {
+    if base.contains("pwsh") {
+        ShellKind::Pwsh
+    } else if base.contains("powershell") {
         ShellKind::PowerShell
     } else if base.contains("fish") {
         ShellKind::Fish
@@ -235,6 +242,9 @@ pub(crate) fn value_ref(shell: ShellKind, env: &str) -> String {
     match shell {
         ShellKind::Posix | ShellKind::Fish => format!("\"${env}\""),
         ShellKind::PowerShell => format!("$($env:{env} -replace '\"', '\\\"')"),
+        // pwsh re-quotes the argument itself, so the value is passed as-is; escaping here would
+        // reach the agent as literal backslashes and produce the very error the arm above prevents.
+        ShellKind::Pwsh => format!("\"$env:{env}\""),
         ShellKind::Cmd => format!("\"%{env}%\""),
     }
 }
@@ -245,7 +255,7 @@ pub(crate) fn value_ref(shell: ShellKind, env: &str) -> String {
 /// is independent of the `--settings` fix.
 fn prompt_ref(shell: ShellKind, env: &str) -> String {
     match shell {
-        ShellKind::PowerShell => format!("\"$env:{env}\""),
+        ShellKind::PowerShell | ShellKind::Pwsh => format!("\"$env:{env}\""),
         _ => value_ref(shell, env),
     }
 }
@@ -543,7 +553,7 @@ fn valid_resume_id(id: &str) -> Option<&str> {
 /// metacharacters so they can be embedded safely in quoted strings and cmd.exe blocks.
 fn not_found_message(shell: ShellKind, bin: &str) -> String {
     match shell {
-        ShellKind::PowerShell => format!(
+        ShellKind::PowerShell | ShellKind::Pwsh => format!(
             "[VelaTerm] {bin} not found on PATH. Your shell profile may be blocked - run: \
              Set-ExecutionPolicy -Scope CurrentUser RemoteSigned, then reopen the session."
         ),
@@ -580,7 +590,7 @@ fn report_not_found_with(shell: ShellKind, msg: &str) -> String {
             "curl -fsS -m 2 \"${NOTFOUND_URL_ENV}\" >/dev/null 2>&1; \
              or wget -qO- -T 2 \"${NOTFOUND_URL_ENV}\" >/dev/null 2>&1; echo '{msg}'"
         ),
-        ShellKind::PowerShell => format!(
+        ShellKind::PowerShell | ShellKind::Pwsh => format!(
             "try {{ Invoke-WebRequest -UseBasicParsing -TimeoutSec 2 $env:{NOTFOUND_URL_ENV} | Out-Null }} \
              catch {{}}; Write-Host '{msg}'"
         ),
@@ -604,7 +614,7 @@ fn clear_prefix(shell: ShellKind) -> &'static str {
         // `printf` interprets \033 inside single quotes as ESC in bash, zsh, dash, and fish.
         ShellKind::Posix | ShellKind::Fish => "printf '\\033[3J\\033[2J\\033[H'; ",
         // Build ESC from `[char]27` for compatibility with Windows PowerShell 5.1 and PowerShell 7+.
-        ShellKind::PowerShell => {
+        ShellKind::PowerShell | ShellKind::Pwsh => {
             "[Console]::Write([char]27 + '[3J' + [char]27 + '[2J' + [char]27 + '[H'); "
         }
         // cmd.exe's built-in `cls` becomes a clear-screen sequence through ConPTY.
@@ -640,7 +650,7 @@ fn launch_cmd(shell: ShellKind, bin: &str, args: &str) -> String {
             "{clear}if command -v {bin} >/dev/null 2>&1; then {inner}; else {report}; fi"
         ),
         ShellKind::Fish => format!("{clear}if type -q {bin}; {inner}; else; {report}; end"),
-        ShellKind::PowerShell => format!(
+        ShellKind::PowerShell | ShellKind::Pwsh => format!(
             "{clear}if (Get-Command {bin} -ErrorAction SilentlyContinue) {{ {inner} }} else {{ {report} }}"
         ),
         ShellKind::Cmd => format!("{clear}where {bin} >nul 2>nul & if errorlevel 1 ({report}) else ({inner})"),
@@ -712,7 +722,7 @@ fn launch_cmd_at(shell: ShellKind, path: &str, args: &str) -> String {
             let report = report_not_found_with(shell, &sq_posix(&path_missing_message(path)));
             format!("{clear}if test -x '{p}'; {inner}; else; {report}; end")
         }
-        ShellKind::PowerShell => {
+        ShellKind::PowerShell | ShellKind::Pwsh => {
             let p = sq_pwsh(path);
             let inner = if args.is_empty() {
                 format!("& '{p}'")
@@ -1489,6 +1499,56 @@ mod tests {
              if command -v opencode >/dev/null 2>&1; then opencode; else"
         ));
         assert!(bare.contains("\"$VLX_NOTFOUND_URL\""));
+    }
+
+    /// `pwsh` and `powershell.exe` need OPPOSITE escaping for a native-command argument, so they must not
+    /// classify to the same kind. Windows PowerShell passes the value through verbatim and needs every `"`
+    /// hand-escaped; pwsh re-quotes the argument itself, so that same escaping arrives as literal
+    /// backslashes and the agent reports `Invalid JSON provided to --settings`. Both behaviours were
+    /// measured on Windows against 5.1.26100 and 7.6.5.
+    #[test]
+    fn shell_kind_separates_windows_powershell_from_pwsh() {
+        assert_eq!(
+            shell_kind(r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"),
+            ShellKind::PowerShell
+        );
+        assert_eq!(
+            shell_kind(r"C:\Program Files\PowerShell\7\pwsh.exe"),
+            ShellKind::Pwsh
+        );
+        assert_eq!(shell_kind("pwsh"), ShellKind::Pwsh);
+        assert_eq!(shell_kind("powershell"), ShellKind::PowerShell);
+    }
+
+    /// The regression this fix exists for: a compact-JSON value must reach the agent unmangled on BOTH
+    /// PowerShell dialects, and that requires different text in each.
+    #[test]
+    fn value_ref_escapes_for_windows_powershell_but_not_for_pwsh() {
+        // Windows PowerShell 5.1 hand-escapes, because it passes the value through untouched.
+        assert_eq!(
+            value_ref(ShellKind::PowerShell, "VLX_CLAUDE_SETTINGS"),
+            r#"$($env:VLX_CLAUDE_SETTINGS -replace '"', '\"')"#
+        );
+        // pwsh must NOT hand-escape; a backslash here survives into the argument itself.
+        assert_eq!(
+            value_ref(ShellKind::Pwsh, "VLX_CLAUDE_SETTINGS"),
+            r#""$env:VLX_CLAUDE_SETTINGS""#
+        );
+        assert!(!value_ref(ShellKind::Pwsh, "X").contains('\\'));
+    }
+
+    /// A prompt is one argument on both dialects. Windows PowerShell still splits a prompt containing `"`
+    /// (a pre-existing limitation noted on `prompt_ref`); pwsh does not, so quoting is enough for both.
+    #[test]
+    fn prompt_ref_quotes_on_both_powershell_dialects() {
+        assert_eq!(
+            prompt_ref(ShellKind::PowerShell, "VLX_PROMPT"),
+            r#""$env:VLX_PROMPT""#
+        );
+        assert_eq!(
+            prompt_ref(ShellKind::Pwsh, "VLX_PROMPT"),
+            r#""$env:VLX_PROMPT""#
+        );
     }
 
     #[test]

--- a/src-tauri/src/agent/inject/powershell_tests.rs
+++ b/src-tauri/src/agent/inject/powershell_tests.rs
@@ -1,0 +1,341 @@
+//! Opt-in tests of the argv received by a native process, rather than only the generated shell text.
+//! Set VLX_TEST_PWSH to a pwsh executable and run this module with `cargo test ... -- --ignored`.
+
+use super::*;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+struct NativeProbe {
+    root: PathBuf,
+    executable: PathBuf,
+}
+
+impl NativeProbe {
+    fn new() -> Self {
+        let target = std::env::var_os("CARGO_TARGET_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target"));
+        let root = target.join(format!("pwsh-args-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&root).unwrap();
+        let source = root.join("argv_probe.rs");
+        std::fs::write(
+            &source,
+            r#"fn main() {
+                let mut output = Vec::new();
+                for argument in std::env::args().skip(1) {
+                    output.extend_from_slice(argument.as_bytes());
+                    output.push(0);
+                }
+                std::fs::write(std::env::var_os("VLX_TEST_ARGV_OUTPUT").unwrap(), output).unwrap();
+            }"#,
+        )
+        .unwrap();
+        let executable = root.join(if cfg!(windows) {
+            "argv-probe.exe"
+        } else {
+            "argv-probe"
+        });
+        let compiler = std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
+        let compiled = Command::new(compiler)
+            .arg(&source)
+            .arg("-o")
+            .arg(&executable)
+            .output()
+            .expect("rustc is required to build the native argv probe");
+        assert!(
+            compiled.status.success(),
+            "{}",
+            String::from_utf8_lossy(&compiled.stderr)
+        );
+        Self { root, executable }
+    }
+
+    fn copy_as(&self, name: &str) -> PathBuf {
+        let path = self.root.join(name);
+        std::fs::copy(&self.executable, &path).unwrap();
+        path
+    }
+
+    fn assert_argv(
+        &self,
+        shell: &str,
+        setup: &str,
+        launch: &str,
+        env: &[(String, String)],
+        expected: &[String],
+    ) {
+        let output = self.root.join("arguments.bin");
+        let _ = std::fs::remove_file(&output);
+        // Run the same launch fragment used by a PTY, after a simulated profile sets its preference.
+        // Deliberately shadow a parent variable to ensure the launcher keeps its state in a child scope.
+        let script = format!(
+            "Set-StrictMode -Version Latest; $ErrorActionPreference = 'Stop'; \
+             {setup}; \
+             $vlxLegacyArguments = 'parent'; \
+             $beforeMode = [string](Get-Variable PSNativeCommandArgumentPassing -ValueOnly -ErrorAction SilentlyContinue); \
+             {launch}; \
+             if ($vlxLegacyArguments -cne 'parent') {{ throw 'Launcher variable escaped its scope' }}; \
+             $afterMode = [string](Get-Variable PSNativeCommandArgumentPassing -ValueOnly -ErrorAction SilentlyContinue); \
+             if ($beforeMode -cne $afterMode) {{ throw 'Launcher changed the argument preference' }}"
+        );
+        let mut command = Command::new(shell);
+        command.args(["-NoLogo", "-NoProfile", "-NonInteractive"]);
+        if cfg!(windows) {
+            command.args(["-ExecutionPolicy", "Bypass"]);
+        }
+        let result = command
+            .arg("-Command")
+            .arg(script)
+            .env("POWERSHELL_TELEMETRY_OPTOUT", "1")
+            .env("VLX_TEST_ARGV_OUTPUT", &output)
+            .envs(env.iter().map(|(key, value)| (key, value)))
+            .output()
+            .unwrap_or_else(|error| panic!("could not execute {shell}: {error}"));
+        assert!(
+            result.status.success(),
+            "PowerShell failed for {setup}: {}",
+            String::from_utf8_lossy(&result.stderr)
+        );
+        let bytes = std::fs::read(&output).expect("the launcher did not invoke the native probe");
+        let actual: Vec<String> = bytes
+            .strip_suffix(&[0])
+            .expect("the native probe must terminate its last argument")
+            .split(|byte| *byte == 0)
+            .map(|argument| String::from_utf8(argument.to_vec()).unwrap())
+            .collect();
+        assert_eq!(actual, expected, "argv mismatch for {setup}");
+    }
+}
+
+impl Drop for NativeProbe {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+fn shell_capabilities(shell: &str) -> ((u32, u32), bool) {
+    let result = Command::new(shell)
+        .args([
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            "$PSVersionTable.PSVersion.ToString(); $EnabledExperimentalFeatures",
+        ])
+        .env("POWERSHELL_TELEMETRY_OPTOUT", "1")
+        .output()
+        .unwrap_or_else(|error| panic!("PowerShell is required; set VLX_TEST_PWSH: {error}"));
+    assert!(
+        result.status.success(),
+        "{}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    let text = String::from_utf8(result.stdout).unwrap();
+    let mut lines = text.lines();
+    let mut version = lines.next().unwrap().trim().split('.');
+    (
+        (
+            version.next().unwrap().parse().unwrap(),
+            version.next().unwrap().parse().unwrap(),
+        ),
+        lines.any(|line| line.trim() == "PSNativeCommandArgumentPassing"),
+    )
+}
+
+fn path_text(path: &Path) -> &str {
+    path.to_str().unwrap()
+}
+
+#[test]
+#[ignore = "requires pwsh and rustc; set VLX_TEST_PWSH and run with --ignored"]
+fn pwsh_native_arguments_round_trip() {
+    let shell = std::env::var("VLX_TEST_PWSH").unwrap_or_else(|_| "pwsh".into());
+    let (version, experimental) = shell_capabilities(&shell);
+    let setups = if version >= (7, 3) {
+        vec![
+            "$null = 0",
+            "$PSNativeCommandArgumentPassing = 'Legacy'",
+            "$PSNativeCommandArgumentPassing = 'Standard'",
+            "$PSNativeCommandArgumentPassing = 'Windows'",
+            "Remove-Variable PSNativeCommandArgumentPassing -ErrorAction SilentlyContinue",
+        ]
+    } else if experimental {
+        vec![
+            "$null = 0",
+            "$PSNativeCommandArgumentPassing = 'Legacy'",
+            "$PSNativeCommandArgumentPassing = 'Standard'",
+            "Remove-Variable PSNativeCommandArgumentPassing -ErrorAction SilentlyContinue",
+        ]
+    } else {
+        vec!["$null = 0"]
+    };
+    let probe = NativeProbe::new();
+    let endpoint = HookEndpoint {
+        port: 38147,
+        token: "argv-test-token".into(),
+    };
+    let values = vec![
+        build_claude_settings(&endpoint, "argv-test-session"),
+        serde_json::json!({
+            "path": "C:\\Program Files\\VelaTerm\\",
+            "text": "say \"hello world\"; $(literal) `literal` & | %PATH% 中文\nnext line",
+        })
+        .to_string(),
+    ];
+    let notify = build_codex_notify(r"C:\Program Files\VelaTerm\vela.exe");
+    let effort = "model_reasoning_effort=\"high\"".to_string();
+    let args = format!(
+        "--settings {} -c notify={} -c {}",
+        value_ref(ShellKind::Pwsh, "VLX_TEST_SETTINGS"),
+        value_ref(ShellKind::Pwsh, "VLX_TEST_NOTIFY"),
+        value_ref(ShellKind::Pwsh, "VLX_TEST_EFFORT"),
+    );
+
+    let quoted_path = probe.copy_as(if cfg!(windows) {
+        "argv probe [literal] 'quoted'.exe"
+    } else {
+        "argv probe [literal] 'quoted'"
+    });
+    let ps1 = probe.root.join("argv-wrapper.ps1");
+    std::fs::write(
+        &ps1,
+        format!("& '{}' @args", sq_pwsh(path_text(&probe.executable))),
+    )
+    .unwrap();
+
+    // Native executables renamed to .cmd/.bat exercise PowerShell's automatic Legacy selection on
+    // Unix too. They intentionally do not claim coverage of cmd.exe's additional batch-file parsing.
+    let fallback_names = [
+        "argv-probe.cmd",
+        "argv-probe.bat",
+        "cmd.exe",
+        "argv probe [literal] 'quoted'.cmd",
+    ];
+    let fallback_paths: Vec<_> = fallback_names
+        .iter()
+        .map(|name| probe.copy_as(name))
+        .collect();
+
+    for setup in setups {
+        for value in &values {
+            let env = vec![
+                ("VLX_TEST_SETTINGS".into(), value.clone()),
+                ("VLX_TEST_NOTIFY".into(), notify.clone()),
+                ("VLX_TEST_EFFORT".into(), effort.clone()),
+            ];
+            let expected = vec![
+                "--settings".into(),
+                value.clone(),
+                "-c".into(),
+                format!("notify={notify}"),
+                "-c".into(),
+                effort.clone(),
+            ];
+            for path in [&probe.executable, &quoted_path, &ps1] {
+                let launch = launch_cmd_at(ShellKind::Pwsh, path_text(path), &args);
+                probe.assert_argv(&shell, setup, &launch, &env, &expected);
+            }
+            let alias_setup = format!(
+                "{setup}; Set-Alias claude '{}'",
+                sq_pwsh(path_text(&probe.executable))
+            );
+            probe.assert_argv(
+                &shell,
+                &alias_setup,
+                &launch_cmd(ShellKind::Pwsh, "claude", &args),
+                &env,
+                &expected,
+            );
+            // On Windows, .cmd/.bat files are interpreted by cmd.exe, so a renamed binary is not a
+            // faithful batch-file fixture. Real Windows wrapper checks belong in their own test.
+            if !cfg!(windows) {
+                for path in &fallback_paths {
+                    let alias_setup =
+                        format!("{setup}; Set-Alias claude '{}'", sq_pwsh(path_text(path)));
+                    probe.assert_argv(
+                        &shell,
+                        setup,
+                        &launch_cmd_at(ShellKind::Pwsh, path_text(path), &args),
+                        &env,
+                        &expected,
+                    );
+                    probe.assert_argv(
+                        &shell,
+                        &alias_setup,
+                        &launch_cmd(ShellKind::Pwsh, "claude", &args),
+                        &env,
+                        &expected,
+                    );
+                }
+            }
+        }
+        // Exercise the production preparation entry point with both structured settings and a prompt.
+        let spawn = prepare_with_args(
+            SessionKind::Claude,
+            &shell,
+            "/unused/vela",
+            &endpoint,
+            "argv-test-session",
+            None,
+            false,
+            Some("review this project"),
+            None,
+            Some(path_text(&probe.executable)),
+            None,
+        );
+        probe.assert_argv(
+            &shell,
+            setup,
+            &spawn.launch.unwrap(),
+            &spawn.env,
+            &[
+                "--settings".into(),
+                values[0].clone(),
+                "review this project".into(),
+            ],
+        );
+
+        // Model/effort fragments are generated outside inject.rs and must share the launcher's scope.
+        let selection = crate::agent::session_settings::Selection {
+            model: Some("example/model".into()),
+            effort: Some("high".into()),
+        };
+        let (extra, selection_env) = crate::agent::session_settings::terminal_args(
+            SessionKind::Codex,
+            ShellKind::Pwsh,
+            None,
+            &selection,
+        );
+        let mut spawn = prepare_with_args_capabilities(
+            SessionKind::Codex,
+            &shell,
+            r"C:\Program Files\VelaTerm\vela.exe",
+            &endpoint,
+            "argv-test-session",
+            None,
+            false,
+            None,
+            Some(&extra),
+            Some(path_text(&probe.executable)),
+            None,
+            None,
+            false,
+        );
+        spawn.env.extend(selection_env);
+        probe.assert_argv(
+            &shell,
+            setup,
+            &spawn.launch.unwrap(),
+            &spawn.env,
+            &[
+                "-c".into(),
+                format!("notify={notify}"),
+                "--no-alt-screen".into(),
+                "--model".into(),
+                "example/model".into(),
+                "-c".into(),
+                effort.clone(),
+            ],
+        );
+    }
+}

--- a/src-tauri/src/agent/session_settings.rs
+++ b/src-tauri/src/agent/session_settings.rs
@@ -543,6 +543,7 @@ mod tests {
                 ShellKind::Posix,
                 ShellKind::Fish,
                 ShellKind::PowerShell,
+                ShellKind::Pwsh,
                 ShellKind::Cmd,
             ] {
                 let selection = pair("custom/$(touch should-not-run)", "high");

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -392,7 +392,9 @@ impl PtyManager {
                     // Agent sessions start PowerShell with a process-local execution-policy bypass so npm `.ps1`
                     // shims and interactive profiles can load. Plain terminals preserve the native policy.
                     // Group Policy can still override the command-line setting.
-                    inject::ShellKind::PowerShell if kind != SessionKind::Terminal => {
+                    inject::ShellKind::PowerShell | inject::ShellKind::Pwsh
+                        if kind != SessionKind::Terminal =>
+                    {
                         cmd.arg("-ExecutionPolicy");
                         cmd.arg("Bypass");
                     }


### PR DESCRIPTION
## The bug

Windows PowerShell 5.1 and PowerShell 6+ pass native-command arguments under **opposite** rules:

- `powershell.exe` (5.1) hands the argument through unmodified, so a value containing `"` must be escaped by hand for `CommandLineToArgvW` to reconstruct it.
- `pwsh` (6+) re-quotes native-command arguments itself. Hand-escaping there **double-escapes**: the backslashes arrive literally.

`shell_kind()` classifies both into one `ShellKind::PowerShell`:

```rust
if base.contains("powershell") || base.contains("pwsh") { ShellKind::PowerShell }
```

and `value_ref()` applies the 5.1 rule to that single variant:

```rust
ShellKind::PowerShell => format!("$($env:{env} -replace '\"', '\\\"')"),
```

So with an agent on `pwsh`, `--settings` receives a JSON string whose inner quotes are escaped twice, and the agent fails to launch with:

```
Invalid JSON provided to --settings
```

## Why this has not shown up before

`default_shell()` in `pty/manager.rs` returns `powershell.exe` for non-terminal sessions on Windows — agents always launch on 5.1, which is exactly the dialect the current escaping is correct for. The defect is only reachable once an agent is pointed at `pwsh` (a configured agent shell, or a `pwsh` entry in a preset). That is why the file can grow without the bug surfacing.

## The fix

Split the dialects into separate variants and give only the one arm that genuinely differs a different body.

- `ShellKind::Pwsh` added alongside `ShellKind::PowerShell`.
- `shell_kind()` tests `pwsh` **before** `powershell`, so `C:\Program Files\PowerShell\7\pwsh.exe` classifies correctly.
- `value_ref()` keeps hand-escaping for 5.1 and passes the value through for `pwsh`.

Every other PowerShell arm is dialect-agnostic and is simply widened to `ShellKind::PowerShell | ShellKind::Pwsh` — `clear_prefix`, `launch_cmd`, `report_not_found_with`, the not-found guidance, and the raw-reference helper. That widening is deliberate and load-bearing: without it, adding the variant would silently drop `pwsh` into a fallback arm and change behaviour well beyond the escaping.

One of those is not cosmetic. `pty/manager.rs` gates the process-local execution-policy bypass on the shell kind:

```rust
inject::ShellKind::PowerShell | inject::ShellKind::Pwsh if kind != SessionKind::Terminal => {
    cmd.arg("-ExecutionPolicy");
    cmd.arg("Bypass");
}
```

Without `| Pwsh` there, a `pwsh` agent session loses the bypass and npm `.ps1` shims stop loading — a second bug introduced by the first fix.

## Tests

Three added, one updated, all in `agent::inject::tests`:

- `shell_kind_separates_windows_powershell_from_pwsh` — including the full `C:\Program Files\PowerShell\7\pwsh.exe` path, which is the case the ordering change exists for.
- `value_ref_escapes_for_windows_powershell_but_not_for_pwsh` — pins the one behavioural difference in both directions, so collapsing the variants again fails here rather than silently returning to the old output.
- `prompt_ref_quotes_on_both_powershell_dialects` — pins the other half: that the widened arms really are dialect-agnostic. Without it, "only `value_ref` differs" is an assertion rather than a tested claim.
- `shell_kind_detects_families` — updated, since it previously asserted the collapsed classification and would otherwise encode the bug as intended behaviour.

## Verification

Rebased onto `7dd2b0b` with no conflicts. On Windows:

- `pnpm lint` — clean.
- `cargo test --lib --no-default-features` — the three new tests and the updated one all pass.

The suite is not green on this platform before the change, so the comparison is against a measured baseline rather than against zero. Stock `7dd2b0b` fails three `git::merge_tests` here; this branch's failures are a **subset** of that set, and no test fails that passes on the baseline.

Two notes on that, so the numbers are reproducible rather than surprising:

- One of those baseline failures is a `core.autocrlf` artefact (`"hello\r\n"` vs `"hello\n"`), not a code defect — it reproduces on stock upstream.
- Several tests in that suite are load-sensitive on Windows and change verdict between runs. A run under CPU contention added one timing failure (`agent::server::tests::serve_with_answers_reads_off_the_accept_loop`, which asserts a millisecond bound); it passes on repeat in isolation, does not recur on an unloaded run, and is in a file this change does not touch.

`agent/inject.rs` and `pty/manager.rs` are the only files changed.

## Credit

Found and fixed by contributors working on this fork. The `pwsh` diagnosis and fix are mine; the corrected `shell_kind_detects_families` assertion and the `default_shell()` reachability analysis above came from a second contributor reviewing the branch.
